### PR TITLE
feat: add CUDA support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,6 +20,7 @@ All CLI defaults can be overridden via environment variables:
 | `ES_TRANSLATOR_SOURCE_FIELD` | Default source field | `content` |
 | `ES_TRANSLATOR_TARGET_FIELD` | Default target field | `content_translated` |
 | `ES_TRANSLATOR_MAX_CONTENT_LENGTH` | Max content length | `19G` |
+| `ES_TRANSLATOR_DEVICE` | Device for Argos (cpu, cuda, auto) | `auto` |
 | `ES_TRANSLATOR_POOL_SIZE` | Default worker pool size | `1` |
 | `ES_TRANSLATOR_POOL_TIMEOUT` | Worker timeout (seconds) | `1800` |
 | `ES_TRANSLATOR_SCAN_SCROLL` | Elasticsearch scroll duration | `5m` |
@@ -89,6 +90,7 @@ es-translator --index my-index -s fr -t en
 | `--plan` | - | `false` | Queue for distributed mode |
 | `--broker-url` | `ES_TRANSLATOR_BROKER_URL` | `redis://localhost:6379` | Celery broker URL |
 | `--max-content-length` | `ES_TRANSLATOR_MAX_CONTENT_LENGTH` | `19G` | Max content length |
+| `--device` | `ES_TRANSLATOR_DEVICE` | `auto` | Device for Argos (cpu, cuda, auto) |
 | `--stdout-loglevel` | - | `ERROR` | Log level |
 | `--syslog-address` | `ES_TRANSLATOR_SYSLOG_ADDRESS` | `localhost` | Syslog address |
 | `--syslog-port` | `ES_TRANSLATOR_SYSLOG_PORT` | `514` | Syslog port |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -221,6 +221,37 @@ es-translator \
   --throttle 100  # 100ms delay
 ```
 
+### GPU Acceleration
+
+Argos supports GPU acceleration via CUDA for faster neural translation:
+
+```bash
+es-translator \
+  --url "http://localhost:9200" \
+  --index my-index \
+  --source-language fr \
+  --target-language en \
+  --device cuda
+```
+
+Available device options:
+
+| Device | Description |
+|--------|-------------|
+| `auto` | Use CUDA if available, otherwise CPU (default) |
+| `cuda` | Force GPU usage (requires CUDA) |
+| `cpu` | Force CPU usage |
+
+You can also set the device via environment variable:
+
+```bash
+export ES_TRANSLATOR_DEVICE=cuda
+es-translator ...
+```
+
+!!! note "CUDA Requirements"
+    GPU acceleration requires a CUDA-compatible GPU and the appropriate CUDA libraries installed. If CUDA is not available and `--device cuda` is specified, translation will fail.
+
 ## Distributed Translation
 
 For very large datasets, distribute translation across multiple servers using Celery and Redis.
@@ -321,6 +352,7 @@ Options:
   --plan                          Queue for distributed translation
   --broker-url TEXT               Redis URL for distributed mode
   --max-content-length TEXT       Max content length (e.g., 10M, 1G)
+  --device [cpu|cuda|auto]        Device for Argos translation (default: auto)
   --stdout-loglevel TEXT          Log level (DEBUG, INFO, WARNING, ERROR)
   --help                          Show help
 ```

--- a/es_translator/cli.py
+++ b/es_translator/cli.py
@@ -188,6 +188,10 @@ def validate_max_content_length(ctx: click.Context, param: click.Parameter, valu
                    "(see http://github.com/ICIJ/datashare/issues/1184)",
               default=config.DEFAULT_MAX_CONTENT_LENGTH,
               callback=validate_max_content_length)
+@click.option('--device',
+              help='Device for Argos translation (cpu, cuda, or auto)',
+              type=click.Choice(['cpu', 'cuda', 'auto'], case_sensitive=False),
+              default=config.DEFAULT_DEVICE)
 def translate(syslog_address: str, syslog_port: int, syslog_facility: str, **options: Any) -> None:
     """Translate documents in an Elasticsearch index.
 

--- a/es_translator/config.py
+++ b/es_translator/config.py
@@ -19,6 +19,10 @@ DEFAULT_SOURCE_FIELD = os.environ.get('ES_TRANSLATOR_SOURCE_FIELD', 'content')
 DEFAULT_TARGET_FIELD = os.environ.get('ES_TRANSLATOR_TARGET_FIELD', 'content_translated')
 DEFAULT_MAX_CONTENT_LENGTH = os.environ.get('ES_TRANSLATOR_MAX_CONTENT_LENGTH', '19G')
 
+# Device configuration (for Argos neural translation)
+# Options: 'cpu', 'cuda', 'auto'
+DEFAULT_DEVICE = os.environ.get('ES_TRANSLATOR_DEVICE', 'auto')
+
 # Worker configuration
 DEFAULT_POOL_SIZE = int(os.environ.get('ES_TRANSLATOR_POOL_SIZE', '1'))
 DEFAULT_POOL_TIMEOUT = int(os.environ.get('ES_TRANSLATOR_POOL_TIMEOUT', str(60 * 30)))

--- a/es_translator/es_translator.py
+++ b/es_translator/es_translator.py
@@ -80,6 +80,7 @@ class EsTranslator:
         self.interpreter_name = options['interpreter']
         self.max_content_length = options.get('max_content_length', -1)
         self.plan = options.get('plan', False)
+        self.device = options.get('device', 'auto')
 
     @property
     def no_progressbar(self) -> bool:
@@ -146,7 +147,8 @@ class EsTranslator:
             'throttle': self.throttle,
             'progressbar': self.progressbar,
             'interpreter': self.interpreter_name,
-            'max_content_length': self.max_content_length
+            'max_content_length': self.max_content_length,
+            'device': self.device
         }
 
     def instantiate_interpreter(self) -> Any:
@@ -305,6 +307,14 @@ class EsTranslator:
         interpreters = (Apertium, Argos,)
         Interpreter = next(
             i for i in interpreters if i.name.lower() == self.interpreter_name.lower())
+        # Pass device option only to Argos (Apertium doesn't support GPU)
+        if Interpreter == Argos:
+            return Interpreter(
+                self.source_language,
+                self.target_language,
+                self.intermediary_language,
+                pack_dir,
+                self.device)
         return Interpreter(
             self.source_language,
             self.target_language,


### PR DESCRIPTION
Enables GPU acceleration for neural machine translation using CUDA when available.

### Changes

- Add `--device` CLI option (cpu, cuda, auto)
- Add `ES_TRANSLATOR_DEVICE` environment variable
- Configure argostranslate device settings in Argos interpreter
- Auto-detect CUDA availability when device=auto (default)
- Document GPU acceleration in usage and configuration guides
